### PR TITLE
Remove multiplication of gain by 10

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/acarsdec
+++ b/rootfs/etc/s6-overlay/scripts/acarsdec
@@ -12,8 +12,6 @@ FREQ_STRING=""
 
 if [ -z "$GAIN" ]; then
     GAIN="-10"
-else
-    GAIN="$(awk '{if ($1 > 0 && $1 < 100) printf "%i", $1 * 10; else printf "%i", $1;}' <<< "$GAIN")"
 fi
 
 ACARS_CMD=("-g" "$GAIN" "-i" "$FEED_ID")


### PR DESCRIPTION
Gain in 10th is not used by acarsdec since 2022 (https://github.com/wiedehopf/acarsdec/commit/d05730803157dc7a2e283ed4ff97fd835e0c5b4b)

Remove the user supplied gain being multiplied by 10.