### PR TITLE
Update SoapySDR parameter

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/acarsdec
+++ b/rootfs/etc/s6-overlay/scripts/acarsdec
@@ -41,7 +41,8 @@ fi
 # loop through the SOAPYSDR string and split on spaces
 if [[ -n "${SOAPYSDR}" ]]; then
 	IFS=' ' read -ra SOAPYSDR_PROCESSED <<< "${SOAPYSDR}"
-	ACARS_CMD+=("${SOAPYSDR_PROCESSED[@]}")
+	# ACARS_CMD+=("${SOAPYSDR_PROCESSED[@]}") # used for acarsdec < 4.0
+	ACARS_CMD+=("--soapysdr" "${SOAPYSDR_PROCESSED[@]}")
 fi
 
 if [ -n "${PPM}" ]; then


### PR DESCRIPTION
Fixes issue in: https://github.com/sdr-enthusiasts/docker-acarsdec/issues/108

TL;DR -- need to use `acarsdec --soapysdr=<soapysdr_params>`  for acarsdec 4.0 changes