### PR TITLE
ci: fix DL3025 in both Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ RUN set -x && \
 # ENTRYPOINT [ "/init" ]
 
 # Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -158,4 +158,4 @@ COPY --from=builder /tmp/acars-bridge/acars-bridge /opt/acars-bridge
 # ENTRYPOINT [ "/init" ]
 
 # Add healthcheck
-HEALTHCHECK --start-period=3600s --interval=600s CMD /scripts/healthcheck.sh
+HEALTHCHECK --start-period=3600s --interval=600s CMD ["/scripts/healthcheck.sh"]


### PR DESCRIPTION
## Problem

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in **v2.15.0** (published 2026-07-30T13:39:01Z). `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

Both Dockerfiles in this repo are affected:

```text
Dockerfile:77
Dockerfile.local:161
```

```console
$ hadolint --config <shared ruleset> Dockerfile Dockerfile.local   # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile Dockerfile.local   # 2.15.1
...DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments  (x2)
rc=1
```

`check_docker` is already `true` here, so this is a latent `Lint` failure on every PR the moment a `flake.lock` bump lands 2.15.x. There is no hadolint job in the deploy workflow, so the deploy path was never at risk.

## Changes

**`fix: use JSON exec form for HEALTHCHECK CMD`** — both Dockerfiles:

```diff
-HEALTHCHECK ... CMD /scripts/healthcheck.sh
+HEALTHCHECK ... CMD ["/scripts/healthcheck.sh"]
```

`Dockerfile.local` is **built by no workflow** — an orphaned local-build variant. It is fixed rather than deleted because the pre-commit hook's file filter is `(^|/)Dockerfile.*+$|\.Dockerfile$`, so it *is* linted and would still fail `Lint`.

No `flake.nix` change was needed.

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions confirmed in the published image, then both forms run side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden:

```text
=== published / shell ===                    === rebuilt / exec ===
healthy                                      healthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=0                                       exit=0
```

Byte-identical output on both sides:

```text
==== Check Service Death Tallies =====
abnormal death tally for acarsdec since last check is: 0: HEALTHY
abnormal death tally for sdrplay since last check is: 0: HEALTHY
abnormal death tally for acars_bridge since last check is: 0: HEALTHY
```

Because this probe **passes**, the failure direction was checked separately on the same image — a passing probe alone cannot prove exec form propagates a non-zero exit. A throwaway layer with `HEALTHCHECK CMD ["/bin/false"]`:

```text
exec-form non-zero -> status=unhealthy  exit=1
```

Image config compared against the published image — only `Test[0]` differs:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":600000000000,"StartPeriod":3600000000000}
```

`Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Also checked:

- hadolint clean over **both** Dockerfiles at 2.14.0 and 2.15.1
- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped
- `docker build --platform linux/amd64` of the primary Dockerfile: succeeds
- No hooks bypassed; no `--no-verify`
